### PR TITLE
Set/clear autosave based on cookie.

### DIFF
--- a/autosave/mixins.py
+++ b/autosave/mixins.py
@@ -170,6 +170,25 @@ class AdminAutoSaveMixin(object):
             "%sautosave/js/autosave.js?v=2" % settings.STATIC_URL,
         ))
 
+    def set_autosave_flag(self, request, response):
+        """
+        If the autosave_success variable was set by javascript, set it to 1 to
+        signal that a save has successfully happened.
+        """
+        if request.COOKIES.get("autosave_success", False) == '0':
+            response.set_cookie("autosave_success", 1)
+        return response
+
+    def response_add(self, request, obj, post_url_continue='../%s/'):
+        response = super(AdminAutoSaveMixin, self).response_add(request, obj, post_url_continue)
+        response = self.set_autosave_flag(request, response)
+        return response
+
+    def response_change(self, request, obj):
+        response = super(AdminAutoSaveMixin, self).response_change(request, obj)
+        response = self.set_autosave_flag(request, response)
+        return response
+
     def render_change_form(self, request, context, add=False, obj=None, **kwargs):
         if 'media' in context:
             get_params = u''

--- a/autosave/mixins.py
+++ b/autosave/mixins.py
@@ -3,6 +3,7 @@ import json
 import functools
 import textwrap
 from datetime import datetime
+from urlparse import urlparse
 
 from django import forms
 from django.contrib import messages
@@ -176,7 +177,8 @@ class AdminAutoSaveMixin(object):
         signal that a save has successfully happened.
         """
         if request.COOKIES.get("autosave_success", False) == '0':
-            response.set_cookie("autosave_success", 1)
+            referer_path = urlparse(request.META['HTTP_REFERER']).path
+            response.set_cookie("autosave_success", 1, path=referer_path)
         return response
 
     def response_add(self, request, obj, post_url_continue='../%s/'):

--- a/autosave/static/autosave/js/autosave.js
+++ b/autosave/static/autosave/js/autosave.js
@@ -3,14 +3,15 @@ var DjangoAutosave = (window.DjangoAutosave) ? DjangoAutosave : {};
 (function($) {
 
     // From http://www.quirksmode.org/js/cookies.html
-    function createCookie(name,value,days) {
+    function createCookie(name,value,days,path) {
         if (days) {
             var date = new Date();
             date.setTime(date.getTime()+(days*24*60*60*1000));
             var expires = "; expires="+date.toGMTString();
         }
         else var expires = "";
-        document.cookie = name+"="+value+expires+"; path=/";
+        if (!path) { path = "/"; }
+        document.cookie = name+"="+value+expires+"; path=" + path;
     }
 
     function readCookie(name) {
@@ -116,8 +117,8 @@ var DjangoAutosave = (window.DjangoAutosave) ? DjangoAutosave : {};
 
         // If "autosave_success" cookie is falsey, set value to 0 and expire in
         // 24 hours.
-        if(!readCookie("autosave_success")) {
-            createCookie("autosave_success", 0, 1);
+        if(readCookie("autosave_success") !== "1") {
+            createCookie("autosave_success", 0, 1, location.pathname);
         } else if (readCookie("autosave_success") === "1"){
             // If "autosave_success" has been modified by the server, clear the
             // autosave.


### PR DESCRIPTION
A more likely use case than a user accidentally closing a window and losing work is that we have a server error after the form has already been submitted. At the point the server error comes through, the autosave will already have been erased.

This change introduced a cookie that is set on the client side via javascript and then modified upon successful save. If the save succeeds, the autosave and the cookie are erased.
