### PR TITLE
Look for classes on anchors rather than href contents

### DIFF
--- a/autosave/mixins.py
+++ b/autosave/mixins.py
@@ -49,7 +49,7 @@ class AdminAutoSaveMixin(object):
             messages.info(request, mark_safe((
                 'Successfully loaded from your latest autosave. '
                 '<a href="">Click here</a> to %(refresh_action)s. '
-                '<a href="#delete-autosave">[discard autosave]</a>'
+                '<a href="#delete-autosave" class="delete-autosave">[discard autosave]</a>'
                 ) % {
                     'refresh_action': 'view the original' if obj else 'clear the form',
                 }))

--- a/autosave/static/autosave/js/autosave.js
+++ b/autosave/static/autosave/js/autosave.js
@@ -42,7 +42,7 @@ var DjangoAutosave = (window.DjangoAutosave) ? DjangoAutosave : {};
         }
     });
 
-    $(document).on('click', '[href=#ignore-autosaved]', function(e) {
+    $(document).on('click', '.ignore-autosaved', function(e) {
         // Clicking this should remove the banner and start autosaving again, replacing
         // the old version.
         e.preventDefault();
@@ -51,7 +51,7 @@ var DjangoAutosave = (window.DjangoAutosave) ? DjangoAutosave : {};
         setTimeout(DjangoAutosave.save, 5000);
     });
 
-    $(document).on('click', '[href="#delete-autosave"]', function(e) {
+    $(document).on('click', '.delete-autosave', function(e) {
         e.preventDefault();
         e.stopPropagation();
         if (confirm("Are you sure you want to delete your autosave?")) {
@@ -64,7 +64,7 @@ var DjangoAutosave = (window.DjangoAutosave) ? DjangoAutosave : {};
     });
 
     // Regenerates the form to submit old data, and posts it.
-    $(document).on('click', '[href=#revert-to-autosaved]', function(e) {
+    $(document).on('click', '.revert-to-autosaved', function(e) {
         e.preventDefault();
 
         // Generate new form data
@@ -238,8 +238,8 @@ var DjangoAutosave = (window.DjangoAutosave) ? DjangoAutosave : {};
         var msg = [
             "It looks like you have a more recent version autosaved at ",
             Date(last_autosaved).toLocaleString(),
-            '. <a href="#revert-to-autosaved">Revert to that</a> or ',
-            ' <a href="#ignore-autosaved">continue with this version</a>?'
+            '. <a href="#revert-to-autosaved" class="revert-to-autosaved">Revert to that</a> or ',
+            ' <a href="#ignore-autosaved" class="ignore-autosaved">continue with this version</a>?'
         ].join('');
         var $alert = $('<li id="autosave-message" class="info"/>').hide().html(msg);
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.8
+current_version = 0.7.9
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name="Django Autosave",
-    version="0.7.8",
+    version="0.7.9",
     author='Jason Goldstein',
     author_email='jason@betheshoe.com',
     url='https://github.com/theatlantic/django-autosave',


### PR DESCRIPTION
After an upgrade of django 1.8 to django 1.11, we were consistently getting errors on autosave to the following effect when clicking on links in the admin:

```
jquery.min.js:2 Uncaught Error: Syntax error, unrecognized expression: [href=#ignore-autosaved]
    at Function.fa.error (jquery.min.js:2)
    at fa.tokenize (jquery.min.js:2)
    at fa.compile (jquery.min.js:2)
    at fa.select (jquery.min.js:2)
    at Function.fa [as find] (jquery.min.js:2)
    at HTMLDocument.handlers (jquery.min.js:3)
    at HTMLDocument.dispatch (jquery.min.js:3)
    at HTMLDocument.r.handle (jquery.min.js:3)
```

I traced this issue back to this library, and found that pointing at classes rather than href tags restored things. I'm not sure what jquery's problem is all of a sudden, but this does seem to resolve it without it being a breaking change.